### PR TITLE
feat(fix): Fixed help command not working in some cases

### DIFF
--- a/src/commands/Utilities/help.js
+++ b/src/commands/Utilities/help.js
@@ -81,7 +81,7 @@ class HelpCommand extends Command {
       embed
         .setAuthor(
           `Help Interface`,
-          `${message.guild.iconURL({ dynamic: true })}`
+          `${message.guild ? message.guild.iconURL({ dynamic: true }) : "https://i.imgur.com/ZOKp8LH.png"}`
         )
         .setThumbnail(`https://i.imgur.com/OpNjeck.png`)
         .setDescription(


### PR DESCRIPTION
## Details

This pull request fixed the issue with help command failing to work when guild has no icon.

## Checklist

- [ x ] Have you followed the [contributing guidelines](https://github.com/Dude-Perfect-Discord-Bot/Dude-Perfect/blob/main/.github/CONTRIBUTING.md)?
- [ x ] Have you explained what your changes do, and why they add value to the Guides?
